### PR TITLE
Wrap period shift and number of scrolls instead of clamping

### DIFF
--- a/plugin.lua
+++ b/plugin.lua
@@ -5461,7 +5461,7 @@ end
 --    settingVars : list of variables used for the current menu [Table]
 function chooseNumScrolls(settingVars)
     _, settingVars.numScrolls = imgui.InputInt("# of scrolls", settingVars.numScrolls, 1, 1)
-    settingVars.numScrolls = clampToInterval(settingVars.numScrolls, 2, 4)
+    settingVars.numScrolls = wrapToInterval(settingVars.numScrolls, 2, 4)
 end
 -- Lets you choose the number of periods to shift over for a sinusoidal wave
 -- Returns whether or not the period shift value changed [Boolean]
@@ -5471,7 +5471,7 @@ function choosePeriodShift(settingVars)
     local oldShift = settingVars.periodsShift
     local _, newShift = imgui.InputFloat("Phase Shift", oldShift, 0.25, 0.25, "%.2f")
     newShift = forceQuarter(newShift)
-    newShift = clampToInterval(newShift, -0.75, 0.75)
+    newShift = wrapToInterval(newShift, -0.75, 1)
     settingVars.periodsShift = newShift
     return oldShift ~= newShift
 end


### PR DESCRIPTION
Addresses a simple usability issue. Phase shift and number of scrolls should wrap around instead of clamping.

Before:
![2024-05-23 19-19-31](https://github.com/kloi34/amoguSV/assets/14614115/e473714c-dd3e-47fd-9322-534d20a8db5b)

After:
![2024-05-23 19-20-04](https://github.com/kloi34/amoguSV/assets/14614115/e76eba59-9992-42c1-af20-ec216413b5d6)

I assume expanding the phase shift to 1 is fine since 0.75 is the same as -0.25. Clamping 0.75 to -0.75 would cause a phase shift in 0.5, which is a worse usability issue than clamping it.